### PR TITLE
Improve libjli.dylib loading in java launcher

### DIFF
--- a/JavaAppLauncher.m
+++ b/JavaAppLauncher.m
@@ -111,14 +111,33 @@ int launch(char *commandName) {
     NSString *runtime = [infoDictionary objectForKey:@JVM_RUNTIME_KEY];
     
     const char *libjliPath = NULL;
+    void *      libJLI     = NULL;
     if (runtime != nil) {
         NSString *runtimePath = [[[NSBundle mainBundle] builtInPlugInsPath] stringByAppendingPathComponent:runtime];
         libjliPath = [[runtimePath stringByAppendingPathComponent:@"Contents/Home/jre/lib/jli/libjli.dylib"] fileSystemRepresentation];
+        libJLI = dlopen(libjliPath, RTLD_LAZY);
+        
+        if (libJLI == NULL)
+        {
+            libjliPath = [[runtimePath stringByAppendingPathComponent:@"Contents/Home/jre/lib/libjli.dylib"] fileSystemRepresentation];
+            libJLI = dlopen(libjliPath, RTLD_LAZY);
+        }
+        
+        if (libJLI == NULL)
+        {
+            libjliPath = [[runtimePath stringByAppendingPathComponent:@"Contents/Home/lib/jli/libjli.dylib"] fileSystemRepresentation];
+            libJLI = dlopen(libjliPath, RTLD_LAZY);
+        }
+        
+        if (libJLI == NULL)
+        {
+            libjliPath = [[runtimePath stringByAppendingPathComponent:@"Contents/Home/lib/libjli.dylib"] fileSystemRepresentation];
+            libJLI = dlopen(libjliPath, RTLD_LAZY);
+        }
     } else {
         libjliPath = LIBJLI_DYLIB;
+        libJLI = dlopen(libjliPath, RTLD_LAZY);
     }
-    
-    void *libJLI = dlopen(libjliPath, RTLD_LAZY);
     
     JLI_Launch_t jli_LaunchFxnPtr = NULL;
     if (libJLI != NULL) {

--- a/JavaAppLauncherEmb.m
+++ b/JavaAppLauncherEmb.m
@@ -111,14 +111,33 @@ int launch(char *commandName) {
     NSString *runtime = [infoDictionary objectForKey:@JVM_RUNTIME_KEY];
     
     const char *libjliPath = NULL;
+    void *      libJLI     = NULL;
     if (runtime != nil) {
         NSString *runtimePath = [[[NSBundle mainBundle] builtInPlugInsPath] stringByAppendingPathComponent:runtime];
         libjliPath = [[runtimePath stringByAppendingPathComponent:@"Contents/Home/jre/lib/jli/libjli.dylib"] fileSystemRepresentation];
+        libJLI = dlopen(libjliPath, RTLD_LAZY);
+        
+        if (libJLI == NULL)
+        {
+            libjliPath = [[runtimePath stringByAppendingPathComponent:@"Contents/Home/jre/lib/libjli.dylib"] fileSystemRepresentation];
+            libJLI = dlopen(libjliPath, RTLD_LAZY);
+        }
+        
+        if (libJLI == NULL)
+        {
+            libjliPath = [[runtimePath stringByAppendingPathComponent:@"Contents/Home/lib/jli/libjli.dylib"] fileSystemRepresentation];
+            libJLI = dlopen(libjliPath, RTLD_LAZY);
+        }
+        
+        if (libJLI == NULL)
+        {
+            libjliPath = [[runtimePath stringByAppendingPathComponent:@"Contents/Home/lib/libjli.dylib"] fileSystemRepresentation];
+            libJLI = dlopen(libjliPath, RTLD_LAZY);
+        }
     } else {
         libjliPath = LIBJLI_DYLIB;
+        libJLI = dlopen(libjliPath, RTLD_LAZY);
     }
-    
-    void *libJLI = dlopen(libjliPath, RTLD_LAZY);
     
     JLI_Launch_t jli_LaunchFxnPtr = NULL;
     if (libJLI != NULL) {


### PR DESCRIPTION
This PR improves how JavaAppLauncher locates and loads libjli.dylib.

Currently, the launcher assumes a fixed path, which may differ between different JDK/JRE distributions on macOS. This can cause the launcher to fail if libjli.dylib is not found in the expected location.

Changes included:
- Added multiple fallback search paths for libjli.dylib:
  - Contents/Home/jre/lib/jli/libjli.dylib
  - Contents/Home/jre/lib/libjli.dylib
  - Contents/Home/lib/jli/libjli.dylib
  - Contents/Home/lib/libjli.dylib
- If `runtime` is not specified, fall back to `LIBJLI_DYLIB` as before.